### PR TITLE
Convert action to use a pre-built docker image

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -6,7 +6,7 @@ on:
     branches:
       - main
     tags:
-      - 'v*'
+      - 'v[0-9]+.[0-9]+.[0-9]+*'
 
 env:
   REGISTRY: ghcr.io
@@ -43,7 +43,6 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}},enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}
-            type=edge
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push Docker image

--- a/action.yaml
+++ b/action.yaml
@@ -23,7 +23,7 @@ outputs:
     description: 'Percentage of lines covered'
 runs:
   using: 'docker'
-  image: 'Dockerfile'
+  image: 'docker://ghcr.io/ecliptical/covdir-report-action:latest'
   args:
     - "--file=${{ inputs.file }}"
     - "--summary=${{ inputs.summary }}" 


### PR DESCRIPTION
Use a pre-built docker image instead building from source every time.