### PR TITLE
fix: use absolute LLVM_PROFILE_FILE to capture subprocess coverage

### DIFF
--- a/.github/workflows/rust-ci.yaml
+++ b/.github/workflows/rust-ci.yaml
@@ -46,6 +46,14 @@ jobs:
   coverage:
     name: Run tests with coverage
     runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: '-Cinstrument-coverage'
+      # Use an absolute path so that instrumented subprocesses spawned with a
+      # changed working directory (e.g. via assert_cmd) still write their
+      # .profraw files to the same directory that grcov scans. A relative path
+      # scatters subprocess coverage data into temp/fixture dirs and grcov
+      # silently reports 0% for the project's own source.
+      LLVM_PROFILE_FILE: '${{ github.workspace }}/target/coverage/%p-%m.profraw'
     steps:
       - name: Check out the source code
         uses: actions/checkout@v6
@@ -64,9 +72,6 @@ jobs:
           components: rustfmt, clippy, llvm-tools
       - name: Run unit tests
         run: cargo test
-        env:
-          RUSTFLAGS: '-Cinstrument-coverage'
-          LLVM_PROFILE_FILE: 'target/coverage/%p-%m.profraw'
       - name: Generate coverage report
         uses: ./
         with:

--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ name: Rust Coverage
 jobs:
   coverage:
     runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: '-Cinstrument-coverage'
+      LLVM_PROFILE_FILE: '${{ github.workspace }}/target/coverage/%p-%m.profraw'
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
@@ -27,14 +30,18 @@ jobs:
           components: llvm-tools
       - name: Test
         run: cargo test
-        env:
-          RUSTFLAGS: '-Cinstrument-coverage'
-          LLVM_PROFILE_FILE: 'target/coverage/%p-%m.profraw'
       - name: Generate coverage report
         uses: ecliptical/covdir-report-action@v0.4
         with:
           summary: 'true'
 ```
+
+> **Note:** `LLVM_PROFILE_FILE` must be an **absolute path** (using `${{ github.workspace }}`).
+> If your tests spawn the project binary as a subprocess with a changed working directory
+> (e.g. via [`assert_cmd`](https://docs.rs/assert_cmd)), a relative path causes each
+> subprocess to write its `.profraw` files into the subprocess's cwd instead of the
+> repo root. grcov only scans the configured `coverage_path`, so those files are never
+> found and coverage is silently reported as 0%.
 
 ## Usage with Pre-generated covdir.json
 
@@ -101,6 +108,9 @@ name: Rust Coverage
 jobs:
   coverage:
     runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: '-Cinstrument-coverage'
+      LLVM_PROFILE_FILE: '${{ github.workspace }}/target/coverage/%p-%m.profraw'
     steps:
       - name: Check out the source code
         uses: actions/checkout@v6
@@ -110,9 +120,6 @@ jobs:
           components: llvm-tools
       - name: Run unit tests
         run: cargo test
-        env:
-          RUSTFLAGS: '-Cinstrument-coverage'
-          LLVM_PROFILE_FILE: 'target/coverage/%p-%m.profraw'
       - name: Generate coverage report
         uses: ecliptical/covdir-report-action@v0.4
         with:


### PR DESCRIPTION
## Summary

- Change `LLVM_PROFILE_FILE` from a relative path to an absolute path using `${{ github.workspace }}` in both the CI workflow and all README examples
- Move `RUSTFLAGS` and `LLVM_PROFILE_FILE` to job-level `env` in the workflow (so they're set before the test step, not scoped to it)
- Add a note to the README explaining *why* the absolute path matters

## Root cause

Discovered while debugging 0% coverage in [`ecliptical/cargo-wsdeps#83`](https://github.com/ecliptical/cargo-wsdeps/pull/83).

The integration tests in `tests/diff.rs` (and similarly `tests/integration.rs` here) spawn the project binary via `assert_cmd` with `cmd.current_dir(<fixture>)`. With a **relative** `LLVM_PROFILE_FILE`, each spawned subprocess writes its `.profraw` files relative to *its* working directory — i.e. into the test fixture dir — not the repo root. grcov only scans `./target/coverage`, so it finds the source files (correct total line count) but zero execution data, silently reporting **0% coverage**.

With an **absolute** path, every subprocess writes to the same directory regardless of cwd.

Reproduced and confirmed locally:
- Relative `target/coverage/%p-%m.profraw` → **0%** (23 stray `.profraw` files scattered across `test-resources/*/target/`)  
- Absolute `$PWD/target/coverage/%p-%m.profraw` → **81.37%**

## Test plan

- [ ] CI on this PR should show non-zero coverage in the step summary